### PR TITLE
Handle importing fields with "unopened" generic types

### DIFF
--- a/Utils/MMReflectionImporter.cs
+++ b/Utils/MMReflectionImporter.cs
@@ -28,6 +28,24 @@ namespace MonoMod.Utils {
                 return importer;
             }
         }
+        
+        // Not all generics are equal: in some cases a type with a generic parameter should be 
+        // considered as a TypeReference with GenericParameters. For instance Bar<T> in
+        //
+        // class Foo<T> : Bar<T>
+        //
+        // In other cases, a type should be considered as a GenericInstanceType.
+        // For instance `self` in
+        //
+        // class Foo<T> { static Foo<T> self; }
+        //
+        // Because in Reflection API both cases yield technically the same TypeInfo, we
+        // differentiate then during resolving to allow proper resolving of the second example
+        // The same thing is done in Cecil, so we port a simplified version of it
+        private enum GenericImportKind {
+            Open,
+            Definition
+        }
 
         public static readonly IReflectionImporterProvider Provider = new _Provider();
         public static readonly IReflectionImporterProvider ProviderNoDefault = new _Provider() { UseDefault = false };
@@ -94,21 +112,38 @@ namespace MonoMod.Utils {
         }
 
         public TypeReference ImportReference(Type type, IGenericParameterProvider context) {
-            if (CachedTypes.TryGetValue(type, out TypeReference typeRef))
-                return typeRef;
+            return _ImportReference(type, context, context != null ? GenericImportKind.Open : GenericImportKind.Definition);
+        }
+
+        private bool _IsGenericInstance(Type type, GenericImportKind importKind) {
+            return type.IsGenericType && !type.IsGenericTypeDefinition ||
+                   type.IsGenericType && type.IsGenericTypeDefinition && importKind == GenericImportKind.Open;
+        }
+
+        private GenericInstanceType _ImportGenericInstance(Type type, IGenericParameterProvider context, TypeReference typeRef) {
+            GenericInstanceType git = new GenericInstanceType(typeRef);
+            foreach (Type arg in type.GetGenericArguments())
+                git.GenericArguments.Add(_ImportReference(arg, context));
+            return git;
+        }
+
+        private TypeReference _ImportReference(Type type, IGenericParameterProvider context, GenericImportKind importKind = GenericImportKind.Open) {
+            if (CachedTypes.TryGetValue(type, out TypeReference typeRef)) {
+                return _IsGenericInstance(type, importKind) ? _ImportGenericInstance(type, context, typeRef) : typeRef;
+            }
 
             if (UseDefault)
                 return CachedTypes[type] = Default.ImportReference(type, context);
 
             if (type.HasElementType) {
                 if (type.IsByRef)
-                    return CachedTypes[type] = new ByReferenceType(ImportReference(type.GetElementType(), context));
+                    return CachedTypes[type] = new ByReferenceType(_ImportReference(type.GetElementType(), context));
 
                 if (type.IsPointer)
-                    return CachedTypes[type] = new PointerType(ImportReference(type.GetElementType(), context));
+                    return CachedTypes[type] = new PointerType(_ImportReference(type.GetElementType(), context));
 
                 if (type.IsArray) {
-                    ArrayType at = new ArrayType(ImportReference(type.GetElementType(), context), type.GetArrayRank());
+                    ArrayType at = new ArrayType(_ImportReference(type.GetElementType(), context), type.GetArrayRank());
                     if (type != type.GetElementType().MakeArrayType()) {
                         // Non-SzArray
                         // TODO: Find a way to get the bounds without instantiating the array type!
@@ -130,13 +165,10 @@ namespace MonoMod.Utils {
                     return CachedTypes[type] = at;
                 }
             }
-
-            bool isGeneric = type.IsGenericType;
-            if (isGeneric && !type.IsGenericTypeDefinition) {
-                GenericInstanceType git = new GenericInstanceType(ImportReference(type.GetGenericTypeDefinition(), context));
-                foreach (Type arg in type.GetGenericArguments())
-                    git.GenericArguments.Add(ImportReference(arg, context));
-                return git;
+            
+            if (_IsGenericInstance(type, importKind)) {
+                return _ImportGenericInstance(type, context,
+                    _ImportReference(type.GetGenericTypeDefinition(), context, GenericImportKind.Definition));
             }
 
             if (type.IsGenericParameter)
@@ -154,7 +186,7 @@ namespace MonoMod.Utils {
             );
 
             if (type.IsNested)
-                typeRef.DeclaringType = ImportReference(type.DeclaringType, context);
+                typeRef.DeclaringType = _ImportReference(type.DeclaringType, context, importKind);
             else if (type.Namespace != null)
                 typeRef.Namespace = type.Namespace;
 
@@ -214,14 +246,20 @@ namespace MonoMod.Utils {
                 field = field.Module.ResolveField(field.MetadataToken);
             }
 
+            var type = _ImportReference(field.FieldType, declaringType);
             return CachedFields[fieldOrig] = new FieldReference(
                 field.Name,
-                ImportReference(field.FieldType, declaringType),
+                type,
                 declaringType
             );
         }
 
         public MethodReference ImportReference(MethodBase method, IGenericParameterProvider context) {
+            return _ImportReference(method, context,
+                context != null ? GenericImportKind.Open : GenericImportKind.Definition);
+        }
+
+        private MethodReference _ImportReference(MethodBase method, IGenericParameterProvider context, GenericImportKind importKind) {
             if (CachedMethods.TryGetValue(method, out MethodReference methodRef))
                 return methodRef;
 
@@ -231,11 +269,12 @@ namespace MonoMod.Utils {
             if (UseDefault)
                 return CachedMethods[method] = Default.ImportReference(method, context);
 
-            if (method.IsGenericMethod && !method.IsGenericMethodDefinition) {
-                GenericInstanceMethod gim = new GenericInstanceMethod(ImportReference((method as MethodInfo).GetGenericMethodDefinition(), context));
+            if (method.IsGenericMethod && !method.IsGenericMethodDefinition ||
+                method.IsGenericMethod && method.IsGenericMethodDefinition && importKind == GenericImportKind.Open) {
+                GenericInstanceMethod gim = new GenericInstanceMethod(_ImportReference((method as MethodInfo).GetGenericMethodDefinition(), context, GenericImportKind.Definition));
                 foreach (Type arg in method.GetGenericArguments())
                     // Generic arguments for the generic instance are often given by the next higher provider.
-                    gim.GenericArguments.Add(ImportReference(arg, context));
+                    gim.GenericArguments.Add(_ImportReference(arg, context));
 
                 return CachedMethods[method] = gim;
             }
@@ -243,8 +282,8 @@ namespace MonoMod.Utils {
             Type declType = method.DeclaringType;
             methodRef = new MethodReference(
                 method.Name,
-                ImportReference(typeof(void), context),
-                declType != null ? ImportReference(declType, context) : ImportModuleType(method.Module, context)
+                _ImportReference(typeof(void), context),
+                declType != null ? _ImportReference(declType, context, GenericImportKind.Definition) : ImportModuleType(method.Module, context)
             );
 
             methodRef.HasThis = (method.CallingConvention & CallingConventions.HasThis) != 0;
@@ -264,13 +303,13 @@ namespace MonoMod.Utils {
                 foreach (Type param in method.GetGenericArguments())
                     methodRef.GenericParameters.Add(new GenericParameter(param.Name, methodRef));
 
-            methodRef.ReturnType = ImportReference((method as MethodInfo)?.ReturnType ?? typeof(void), methodRef);
+            methodRef.ReturnType = _ImportReference((method as MethodInfo)?.ReturnType ?? typeof(void), methodRef);
 
             foreach (ParameterInfo param in method.GetParameters())
                 methodRef.Parameters.Add(new ParameterDefinition(
                     param.Name,
                     (Mono.Cecil.ParameterAttributes) param.Attributes,
-                    ImportReference(param.ParameterType, methodRef)
+                    _ImportReference(param.ParameterType, methodRef)
                 ));
 
             return CachedMethods[methodOrig] = methodRef;

--- a/Utils/MMReflectionImporter.cs
+++ b/Utils/MMReflectionImporter.cs
@@ -246,10 +246,9 @@ namespace MonoMod.Utils {
                 field = field.Module.ResolveField(field.MetadataToken);
             }
 
-            var type = _ImportReference(field.FieldType, declaringType);
             return CachedFields[fieldOrig] = new FieldReference(
                 field.Name,
-                type,
+                _ImportReference(field.FieldType, declaringType),
                 declaringType
             );
         }


### PR DESCRIPTION
When creating a DMD from an existing method, all member references are imported into cecil's system via MonoMod's own `MMReflectionImporter`.  While the importer does magnificent job of properly resolving everything, it seems to struggle with one very obscure case.

Given a display class:
```cs
private class '<>c__6`1'<T> where T : ICacheable
{
      public static BepInEx.Bootstrap.TypeLoader.'<>c__6`1'<!T> '<>9';
}
```
(names preserved for the sake of clarity of subsequent images)

Using a MethodBuilder backend a `ldsfld` of the field produces valid output where the type of the field is a `GenericInstanceType`:

![image](https://user-images.githubusercontent.com/13762037/87249814-fa68be00-c469-11ea-899a-a946359e3a52.png)

However, using cecil backend, the generic instance information gets lost and the type of the field reference becomes an invalid `TypeReference`:

![image](https://user-images.githubusercontent.com/13762037/87249842-2f751080-c46a-11ea-9ad4-aa87cf52e8de.png)

This in turn caused an exception when running a method generated with cecil backend:

```
[Fatal  :   BepInEx] System.MissingFieldException: Field '.<>c__6`1.<>9' not found.

IntPtr RuntimeMethodHandle.GetFunctionPointer()
IntPtr MonoMod.RuntimeDetour.Platforms.DetourRuntimeILPlatform.GetFunctionPointer(MethodBase, RuntimeMethodHandle)
IntPtr MonoMod.RuntimeDetour.Platforms.DetourRuntimeILPlatform.GetNativeStart(MethodBase)
IntPtr MonoMod.RuntimeDetour.DetourHelper.GetNativeStart(MethodBase)
```

After some testing I routed the problem back to MM's own reflection importer, which doesn't differentiate "open" imports from direct imports like [cecil does](https://github.com/jbevain/cecil/blob/master/Mono.Cecil/Import.cs#L371). 

This PR ports a minimal part of cecil's importer to take into account open/direct imports. I have tested this change with a set of a hundred different patches, so this shouldn't be a breaking change.

DynamicMethod and MethodBuilder backends shouldn't be affected, as all cecil type references are resolved back into Reflection API ones (which is the reason MethodBuilder backend works in the first place).