### PR TITLE
Don't check for errors if OpenLibrary or GetFunction return a valid pointer

### DIFF
--- a/Utils/DynDll.cs
+++ b/Utils/DynDll.cs
@@ -89,13 +89,7 @@ namespace MonoMod.Utils {
         /// <param name="flags">Any optional platform-specific flags.</param>
         /// <returns>True if the handle was obtained, false otherwise.</returns>
         public static bool TryOpenLibrary(string name, out IntPtr libraryPtr, bool skipMapping = false, int? flags = null) {
-            if (!InternalTryOpenLibrary(name, out libraryPtr, skipMapping, flags))
-                return false;
-
-            if (!CheckError(out _))
-                return false;
-
-            return true;
+            return InternalTryOpenLibrary(name, out libraryPtr, skipMapping, flags) || CheckError(out _);
         }
 
         private static bool InternalTryOpenLibrary(string name, out IntPtr libraryPtr, bool skipMapping, int? flags) {
@@ -162,13 +156,7 @@ namespace MonoMod.Utils {
         /// <param name="functionPtr">The function pointer, or null if it wasn't found.</param>
         /// <returns>True if the function pointer was obtained, false otherwise.</returns>
         public static bool TryGetFunction(this IntPtr libraryPtr, string name, out IntPtr functionPtr) {
-            if (!InternalTryGetFunction(libraryPtr, name, out functionPtr))
-                return false;
-
-            if (!CheckError(out _))
-                return false;
-
-            return true;
+            return InternalTryGetFunction(libraryPtr, name, out functionPtr) || CheckError(out _);
         }
 
         private static bool InternalTryGetFunction(IntPtr libraryPtr, string name, out IntPtr functionPtr) {


### PR DESCRIPTION
For some reason `TryOpenLibrary` or `TryGetFunction` can return `false` despite also returning a valid address to a library or a function.

This was reproduced on Windows 8.1

```
Trying to open library msvcrt.dll
Loading library msvcrt.dll
Return of LoadLibrary: 140729505939456
Library not null: True
Checking for errors...
Last win32 error: 126 (hex: 7E)
```

This change prevents calling `CheckError` if the returned function or library address is non-null.