### PR TITLE
WIP: Generate dynamic generic method definitions

### DIFF
--- a/Utils/Cil/CecilILGenerator.cs
+++ b/Utils/Cil/CecilILGenerator.cs
@@ -79,9 +79,9 @@ namespace MonoMod.Utils.Cil {
 
         private VariableDefinition _(LocalBuilder handle) => _Variables[handle];
 
-        private TypeReference _(Type info) => IL.Body.Method.Module.ImportReference(info);
-        private FieldReference _(FieldInfo info) => IL.Body.Method.Module.ImportReference(info);
-        private MethodReference _(MethodBase info) => IL.Body.Method.Module.ImportReference(info);
+        private TypeReference _(Type info) => info.IsGenericParameter ? new GenericParameter(info.Name, IL.Body.Method) : IL.Body.Method.Module.ImportReference(info);
+        private FieldReference _(FieldInfo info) => IL.Body.Method.Module.ImportReference(info, IL.Body.Method);
+        private MethodReference _(MethodBase info) => IL.Body.Method.Module.ImportReference(info, IL.Body.Method);
 
         private int _ILOffset;
         public override int ILOffset => _ILOffset;

--- a/Utils/MMReflectionImporter.cs
+++ b/Utils/MMReflectionImporter.cs
@@ -241,7 +241,7 @@ namespace MonoMod.Utils {
                 }
             }
 
-            throw new NotSupportedException();
+            return new GenericParameter(type.Name, context);
         }
 
         public FieldReference ImportReference(FieldInfo field, IGenericParameterProvider context) {


### PR DESCRIPTION
WORK IN PROGRESS

Adds support for generating generic dynamic method _definitions_. This means that `Method<T>` can be generated at runtime, as opposed to a fixed `Method<object>`. Then `.MakeGenericMethod` can be called on the resulting definition to get a final method to call.

So far, when using Harmony, a static generic method of a non-generic class can be generated, and the original replaced, and the generic type data is not lost.

This only works when using a `MethodBuilder` right now. `DynamicMethod` does not support generics. I do not know whether Cecil can generate generics.