### PR TITLE
DynDll: call dlerror at least once to fix false result on first call

### DIFF
--- a/Utils/DynDll.cs
+++ b/Utils/DynDll.cs
@@ -44,6 +44,12 @@ namespace MonoMod.Utils {
 
         #endregion
 
+        static DynDll() {
+            // Run a dummy dlerror to resolve it so that it won't interfere with the first call
+            if (!PlatformHelper.Is(Platform.Windows))
+                dlerror();
+        }
+
         private static bool CheckError(out Exception exception) {
             if (PlatformHelper.Is(Platform.Windows)) {
                 int errorCode = Marshal.GetLastWin32Error();


### PR DESCRIPTION
On some *nix OSes it appears that Unity mono uses some of `dl` functions when resolving `DllImport`s. This causes a problem with importing `dlerror` in the following process:

1. DynDll calls some of `dl` functions (most commonly it's `dlopen`)
2. `dlopen` fails and returns null
3. `dlerror` is called to check for error
4. `dlerror` is resolved with some of `dl` function on mono side, which resets the error flag
5. The real call to `dlerror` returns no error because the flag was reset in step 4
6. DynDll assumes that no error means good result and proceeds to try to resolve symbols from nullptr, which causes NRE

This issue has been noticed at least on macOS 10.15.7, see BepInEx/BepInEx#147.

The PR fixes the problem by calling dlerror once at the start of DynDll so that it's properly resolved at a start. One possible consideration is to leave out error checking and simplify error detection to simply checking for nullptr (for library and symbol loading). This would be a more substantial change, which is why I opted in for a simpler solution.