### PR TITLE
GCListener: Use Environment.HasShutdownStarted to check for runtime shutdown

### DIFF
--- a/Utils/GCListener.cs
+++ b/Utils/GCListener.cs
@@ -41,7 +41,7 @@ namespace MonoMod.Utils {
 
         private sealed class CollectionDummy {
             ~CollectionDummy() {
-                Unloading |= AppDomain.CurrentDomain.IsFinalizingForUnload();
+                Unloading |= Environment.HasShutdownStarted;
 
                 if (!Unloading)
                     GC.ReRegisterForFinalize(this);

--- a/Utils/GCListener.cs
+++ b/Utils/GCListener.cs
@@ -41,7 +41,7 @@ namespace MonoMod.Utils {
 
         private sealed class CollectionDummy {
             ~CollectionDummy() {
-                Unloading |= Environment.HasShutdownStarted;
+                Unloading |= AppDomain.CurrentDomain.IsFinalizingForUnload() || Environment.HasShutdownStarted;
 
                 if (!Unloading)
                     GC.ReRegisterForFinalize(this);


### PR DESCRIPTION
Using `AppDomain.CurrentDomain.IsFinalizingForUnload()` is not viable on Unity as the mono finalizer thread will be run before AppDomain is marked for unloading. This causes an infinite finalizer loop that locks mono runtime from shutting down and makes the game unresponsive when exiting (see for https://github.com/BepInEx/BepInEx/issues/290 for a side-effect of this). 

This fix checks both for root domain unloading and runtime shutdown at the same time which fixes the loop on mono. I have not tested this on other CLRs but [documentation for `HasShutdownStarted`](https://docs.microsoft.com/en-us/dotnet/api/system.environment.hasshutdownstarted?view=net-5.0) implies that `AppDomain.IsFinalizingForUnload()` is used as one of the checks (which is true at least on mono).