### PR TITLE
Fixed a weird FileLoadException on Thai and other regions.

### DIFF
--- a/Utils/ReflectionHelper.cs
+++ b/Utils/ReflectionHelper.cs
@@ -282,7 +282,7 @@ namespace MonoMod.Utils {
                      * - ade
                      */
 
-                    int split = asmName.IndexOf(AssemblyHashNameTag);
+                    int split = asmName.IndexOf(AssemblyHashNameTag, StringComparison.Ordinal);
                     if (split != -1 && int.TryParse(asmName.Substring(split + 2), out int hash)) {
                         asms = AppDomain.CurrentDomain.GetAssemblies().Where(other => other.GetHashCode() == hash).ToArray();
                         if (asms.Length == 0)


### PR DESCRIPTION
A lack of `StringComparison.Ordinal` in a `string.IndexOf` call resulted in MonoMod failing to find the instance of its own assembly, as the method kept returning `0` no matter what.. specifically on Thai systems?