### PR TITLE
Fix Android support by bypassing SELinux

### DIFF
--- a/Utils/PlatformHelper.cs
+++ b/Utils/PlatformHelper.cs
@@ -21,6 +21,9 @@ namespace MonoMod.Utils {
             if (!string.IsNullOrEmpty(windir) && windir.Contains(@"\", StringComparison.Ordinal) && Directory.Exists(windir)) {
                 _current = Platform.Windows;
 
+            } else if (Directory.Exists("/data") && File.Exists("/system/build.prop")) {   // Android Device
+                _current = Platform.Android;  // We cannot directly use /proc/sys/kernel/ostype to determine an Android Device
+                                              // because of the strict SELinux policies after Lollipop
             } else if (File.Exists("/proc/sys/kernel/ostype")) {
                 string osType = File.ReadAllText("/proc/sys/kernel/ostype");
                 if (osType.StartsWith("Linux", StringComparison.OrdinalIgnoreCase)) {
@@ -55,12 +58,7 @@ namespace MonoMod.Utils {
             }
 #endif
 
-            if (Is(Platform.Linux) &&
-                Directory.Exists("/data") && File.Exists("/system/build.prop")
-            ) {
-                _current = Platform.Android;
-
-            } else if (Is(Platform.Unix) &&
+            if (Is(Platform.Unix) &&
                 Directory.Exists("/Applications") && Directory.Exists("/System") &&
                 Directory.Exists("/User") && !Directory.Exists("/Users")
             ) {

--- a/Utils/PlatformHelper.cs
+++ b/Utils/PlatformHelper.cs
@@ -21,8 +21,8 @@ namespace MonoMod.Utils {
             if (!string.IsNullOrEmpty(windir) && windir.Contains(@"\", StringComparison.Ordinal) && Directory.Exists(windir)) {
                 _current = Platform.Windows;
 
-            } else if (Directory.Exists("/data") && File.Exists("/system/build.prop")) {   // Android Device
-                _current = Platform.Android;  // We cannot directly use /proc/sys/kernel/ostype to determine an Android Device
+            } else if (Directory.Exists("/etc/selinux")){   // SELinux enabled, access to /proc/sys/kernel/ostype might fail
+                _current = Platform.Linux;  // We cannot directly use /proc/sys/kernel/ostype to determine an Android Device
                                               // because of the strict SELinux policies after Lollipop
             } else if (File.Exists("/proc/sys/kernel/ostype")) {
                 string osType = File.ReadAllText("/proc/sys/kernel/ostype");
@@ -58,14 +58,19 @@ namespace MonoMod.Utils {
             }
 #endif
 
-            if (Is(Platform.Unix) &&
-                Directory.Exists("/Applications") && Directory.Exists("/System") &&
-                Directory.Exists("/User") && !Directory.Exists("/Users")
+            if (Is(Platform.Linux) &&
+                Directory.Exists("/data") && File.Exists("/system/build.prop")
+            ) {
+                _current = Platform.Android;
+
+            } else if (Is(Platform.Unix) &&
+              Directory.Exists("/Applications") && Directory.Exists("/System") &&
+              Directory.Exists("/User") && !Directory.Exists("/Users")
             ) {
                 _current = Platform.iOS;
 
             } else if (Is(Platform.Windows) &&
-                CheckWine()
+              CheckWine()
             ) {
                 // Sorry, Wine devs, but you might want to look at DetourRuntimeNETPlatform.
                 _current |= Platform.Wine;


### PR DESCRIPTION
Use /data directory and /system/build.prop to identify android device, since `/proc/sys/kernel/ostype` is inaccessible on later version of Android (>=5.0) because of SELinux policies.