### PR TITLE
Add callvirt get_Assembly fix for DMDEmit as well

### DIFF
--- a/Utils/DMDGenerators/DMDEmit.cs
+++ b/Utils/DMDGenerators/DMDEmit.cs
@@ -184,7 +184,11 @@ namespace MonoMod.Utils {
                         operand = member;
 #if !NETSTANDARD
                         if (mb != null && member != null) {
-                            Assembly asm = member.Module?.Assembly;
+                            // See DMDGenerator.cs for the explanation of this forced .?
+                            Module module = member?.Module;
+                            if (module == null)
+                                continue;
+                            Assembly asm = module.Assembly;
                             if (asm != null && !accessChecksIgnored.Contains(asm)) {
                                 // while (member.DeclaringType != null)
                                 //     member = member.DeclaringType;


### PR DESCRIPTION
Apparently, this is still present in Unity 2019.

Replicated in Escape to Tarkov:

```
HarmonyLib.HarmonyException: IL Compile Error (unknown location) ---> HarmonyLib.HarmonyException: IL Compile Error (unknown location) ---> System.NotImplementedException: Derived classes must implement it
  at System.Reflection.Module.get_Assembly () [0x00005] in <eae584ce26bc40229c1b1aa476bfa589>:0 
  at MonoMod.Utils._DMDEmit.Generate (MonoMod.Utils.DynamicMethodDefinition dmd, System.Reflection.MethodBase _mb, System.Reflection.Emit.ILGenerator il) [0x005f3] in <b6be78b585f34b8294ca7a4c1df868d5>:0 
  at MonoMod.Utils.DMDEmitMethodBuilderGenerator.GenerateMethodBuilder (MonoMod.Utils.DynamicMethodDefinition dmd, System.Reflection.Emit.TypeBuilder typeBuilder) [0x00378] in <b6be78b585f34b8294ca7a4c1df868d5>:0 
  at MonoMod.Utils.DMDEmitMethodBuilderGenerator._Generate (MonoMod.Utils.DynamicMethodDefinition dmd, System.Object context) [0x00007] in <b6be78b585f34b8294ca7a4c1df868d5>:0 
  at MonoMod.Utils.DMDGenerator`1[TSelf].Generate (MonoMod.Utils.DynamicMethodDefinition dmd, System.Object context) [0x00013] in <b6be78b585f34b8294ca7a4c1df868d5>:0 
  at MonoMod.Utils.DynamicMethodDefinition.Generate (System.Object context) [0x00132] in <b6be78b585f34b8294ca7a4c1df868d5>:0 
  at MonoMod.Utils.DynamicMethodDefinition.Generate () [0x00000] in <b6be78b585f34b8294ca7a4c1df868d5>:0 
```