### PR TITLE
Add check for missing System.RuntimeType

### DIFF
--- a/Utils/ReflectionHelper.FixReflectionCache.cs
+++ b/Utils/ReflectionHelper.FixReflectionCache.cs
@@ -27,13 +27,10 @@ namespace MonoMod.Utils {
             .GetType("System.RuntimeType");
 
         private static Type t_RuntimeTypeCache =
-            t_RuntimeType.GetNestedType("RuntimeTypeCache", BindingFlags.Public | BindingFlags.NonPublic);
+            t_RuntimeType?.GetNestedType("RuntimeTypeCache", BindingFlags.Public | BindingFlags.NonPublic);
 
         private static PropertyInfo p_RuntimeType_Cache =
-            t_RuntimeTypeCache == null ? null :
-            typeof(Type).Assembly
-            .GetType("System.RuntimeType")
-            ?.GetProperty("Cache", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, t_RuntimeTypeCache, Type.EmptyTypes, null);
+            t_RuntimeTypeCache?.GetProperty("Cache", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, t_RuntimeTypeCache, Type.EmptyTypes, null);
 
         private static MethodInfo m_RuntimeTypeCache_GetFieldList =
             typeof(Type).Assembly


### PR DESCRIPTION
Fixes missing null check in 0eb9a4a702e1c4041c50d7c919fd429f50705876 which caused NRE when, for instance, using `DynamicMethodDefinition`.

Example of error this PR fixes (reproduced on Unity 5.2.2):
```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.TypeInitializationException: An exception was thrown by the type initializer for HarmonyLib.AccessTools ---> System.TypeInitializationException: An exception was thrown by the type initializer for MonoMod.Utils.DynamicMethodDefinition ---> System.TypeInitializationException: An exception was thrown by the type initializer for MonoMod.Utils.ReflectionHelper ---> System.NullReferenceException: Object reference not set to an instance of an object
  at MonoMod.Utils.ReflectionHelper..cctor () [0x00000] in <filename unknown>:0 
  --- End of inner exception stack trace ---
  at MonoMod.Utils.DynamicMethodDefinition..cctor () [0x00000] in <filename unknown>:0 
  --- End of inner exception stack trace ---
  at HarmonyLib.MethodInvoker.GetHandler (System.Reflection.MethodInfo methodInfo, Boolean directBoxValueAccess) [0x00000] in <filename unknown>:0 
  at HarmonyLib.AccessTools..cctor () [0x00000] in <filename unknown>:0 
  --- End of inner exception stack trace ---
  at HarmonyLib.Internal.RuntimeFixes.StackTraceFixes.Install () [0x00000] in <filename unknown>:0 
  --- End of inner exception stack trace ---
  at System.Reflection.MonoMethod.Invoke (System.Object obj, BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00000] in <filename unknown>:0 
  at System.Reflection.MethodBase.Invoke (System.Object obj, System.Object[] parameters) [0x00000] in <filename unknown>:0 
```