### PR TITLE
Parse MethodDescs to obtain function ptrs on .NET Core 3.0+

### DIFF
--- a/RuntimeDetour/Platforms/Native/DetourNativeX86Platform.cs
+++ b/RuntimeDetour/Platforms/Native/DetourNativeX86Platform.cs
@@ -57,8 +57,9 @@ namespace MonoMod.RuntimeDetour.Platforms {
                 Method = from,
                 Target = to
             };
-            detour.Size = DetourSizes[detour.Type = type ?? (byte) GetDetourType(from, to, ref detour.Extra)];
-            // Console.WriteLine($"{nameof(DetourNativeX86Platform)} create: {(DetourType) detour.Type} 0x{detour.Method.ToString("X16")} + 0x{detour.Size.ToString("X8")} -> 0x{detour.Target.ToString("X16")}");
+            detour.Type = type ?? (byte) GetDetourType(from, to, ref detour.Extra);
+            // MMDbgLog.Log($"{nameof(DetourNativeX86Platform)} create: {(DetourType) detour.Type} (override: {(type is byte ? ((DetourType) type.Value).ToString() : "<null>")}) 0x{detour.Method.ToString("X16")} -> 0x{detour.Target.ToString("X16")}");
+            detour.Size = DetourSizes[detour.Type];
             return detour;
         }
 

--- a/RuntimeDetour/Platforms/Runtime/DetourRuntimeNETPlatform.cs
+++ b/RuntimeDetour/Platforms/Runtime/DetourRuntimeNETPlatform.cs
@@ -1,6 +1,6 @@
 ﻿// These should be defined as part of your build process,
 // but if you want to test them quickly...
-// #define MONOMOD_RUNTIMEDETOUR_NET_SCAN_MANUAL
+#define MONOMOD_RUNTIMEDETOUR_NET_SCAN_MANUAL
 // #define MONOMOD_RUNTIMEDETOUR_NET_SCAN_AUTO
 // Default to automatic only.
 #if !MONOMOD_RUNTIMEDETOUR_NET_SCAN_MANUAL && !MONOMOD_RUNTIMEDETOUR_NET_SCAN_AUTO

--- a/Shared/MMDbgLog.cs
+++ b/Shared/MMDbgLog.cs
@@ -56,15 +56,16 @@ namespace MonoMod {
             }
 
             if (string.IsNullOrEmpty(path))
-                path = "mmdbglog.txt";
-            path = Path.GetFullPath($"{Path.GetFileNameWithoutExtension(path)}-{Tag}{Path.GetExtension(path)}");
+                path = Path.Combine(Environment.CurrentDirectory, "mmdbglog.txt");
+            path = Path.GetFullPath(path);
+            string dir = Path.GetDirectoryName(path);
+            path = Path.Combine(dir, $"{Path.GetFileNameWithoutExtension(path)}-{Tag}{Path.GetExtension(path)}");
 
             try {
                 if (File.Exists(path))
                     File.Delete(path);
             } catch { }
             try {
-                string dir = Path.GetDirectoryName(path);
                 if (!Directory.Exists(dir))
                     Directory.CreateDirectory(dir);
                 Writer = new StreamWriter(new FileStream(path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete), Encoding.UTF8);


### PR DESCRIPTION
This PR introduces `MethodDesc` parsing for .NET Core 3.0+, which can be opt out of by setting the environment variable `MONOMOD_RUNTIMEDETOUR_NETCORE30PLUS_OLDFTNPTR` to `1`.

Quoting myself from the MonoMod Discord server:

> I see it as either "keep up with runtime internals by parsing methoddescs" or "keep up with runtime internals on a per platform basis by trying to understand what the JIT emits"
> in the past, the runtime was a black box and "fixing" RuntimeMethodHandle.GetFunctionPointer might've been less effort than trying to understand methoddescs
> but nowadays precode walking is stable enough on framework, coreclr is open source, yet another platform is on the horizon, and it feels like there are more combinations of stubs and platforms than there are variations of method descriptors to grab pointers from

Reducing the dependency on precode walking should also theoretically help with getting new platforms up and running faster, such as ARM. My current focus is fixing an edge case interaction between RuntimeDetour and coreclr's backpatcher though, discovered by tModLoader modders, where RuntimeDetour's precode walker misinterprets the location of the method desc in the method table as the location of the code and zeroes it out, shortly before the runtime dies on a backpatch attempt.