### PR TITLE
Don't generate __thiscall return wrapper for primitive values

### DIFF
--- a/RuntimeDetour/Platforms/Runtime/DetourRuntimeILPlatform.cs
+++ b/RuntimeDetour/Platforms/Runtime/DetourRuntimeILPlatform.cs
@@ -326,6 +326,11 @@ namespace MonoMod.RuntimeDetour.Platforms {
             }
         }
 
+        private static bool IsStruct(Type t) {
+            if (t == null) return false;
+            return t.IsValueType && !t.IsPrimitive && !t.IsEnum;
+        }
+
         public MethodBase GetDetourTarget(MethodBase from, MethodBase to) {
             to = GetIdentifiable(to);
 
@@ -335,9 +340,9 @@ namespace MonoMod.RuntimeDetour.Platforms {
             if (from is MethodInfo fromInfo && !from.IsStatic &&
                 to is MethodInfo toInfo && to.IsStatic &&
                 fromInfo.ReturnType == toInfo.ReturnType &&
-                fromInfo.ReturnType.IsValueType &&
+                IsStruct(fromInfo.ReturnType) &&
                 (glueThiscallStructRetPtr =
-                    from.DeclaringType?.IsValueType ?? false && from.GetParameters().Length == 0 ? GlueThiscallInStructRetPtr :
+                    IsStruct(from.DeclaringType) && from.GetParameters().Length == 0 ? GlueThiscallInStructRetPtr :
                     GlueThiscallStructRetPtr
                 ) != GlueThiscallStructRetPtrOrder.Original) {
 


### PR DESCRIPTION
On x86, assume the following method signature:

```cs
class Foo {
  long Method(int a, int b) {}
}
```

In other words, the method returns a *primitive* value type, in which case there is no
__thiscall return value pointer. However, the __thiscall return wrapper was still generated because it passes the current wrapper generator check:

https://github.com/MonoMod/MonoMod.Common/blob/25de541033dc93528ca78cc7ac20a7bcb66dc48c/RuntimeDetour/Platforms/Runtime/DetourRuntimeILPlatform.cs#L335-L346

Specifically:

* `fromInfo.ReturnType.IsValueType == typeof(long).IsValueType == true` -> passes the first `if`
* `sizeof(long) > IntPtr.Size` $\Leftrightarrow$ ` 8 > 4` $\Leftrightarrow$  `true`  (because we're running x86, specifically 32-bit) -> passes second `if`

This causes argument shifting, observed at least in Unity 2018 and .NET 6.

This commit fixes the logic by modifying `IsValueType` => `IsValueType && !IsPrimitive && !IsEnum` which prevents
non-struct return values getting __thiscall return wrappers. The logic is similar to Harmony 2:s return buffer check:

https://github.com/pardeike/Harmony/blob/d1aa13b919adf1089ec8b3198c5c081873c51440/Harmony/Internal/StructReturnBufferCheck.cs#L117

This PR was tested on UnityMono (MonoBleedingEdge) and CoreCLR (.NET 5 & 6). For the latter, a Unit test was written (https://github.com/MonoMod/MonoMod/pull/99) and run locally on 32bit CoreCLR