### PR TITLE
Fix for wine when using CoreCLR

### DIFF
--- a/RuntimeDetour/Platforms/Runtime/DetourRuntimeILPlatform.cs
+++ b/RuntimeDetour/Platforms/Runtime/DetourRuntimeILPlatform.cs
@@ -82,8 +82,8 @@ namespace MonoMod.RuntimeDetour.Platforms {
                 using (DynamicMethodDefinition copy = new DynamicMethodDefinition(_MemAllocScratchDummy)) {
                     copy.Name = $"MemAllocScratch<Reference>";
                     scratch = DMDEmitDynamicMethodGenerator.Generate(copy);
+                    Pin(scratch);
                 }
-                Pin(scratch);
                 ReferenceDynamicPoolPtr = GetNativeStart(scratch);
             }
         }


### PR DESCRIPTION
Fix a stackoverflowexception when using CoreCLR 6.0 (likely due to the DMD being garbage collected) with wine on Linux